### PR TITLE
Upgrades: fix bourbon deprecation warnings

### DIFF
--- a/source/stylesheets/base/_buttons.scss
+++ b/source/stylesheets/base/_buttons.scss
@@ -1,7 +1,7 @@
 button,
 input[type="submit"] {
   @extend %button;
-  @include appearance(none);
+  appearance: none;
   border: none;
   cursor: pointer;
   user-select: none;

--- a/source/stylesheets/base/_forms.scss
+++ b/source/stylesheets/base/_forms.scss
@@ -29,8 +29,8 @@ label {
 textarea,
 #{$all-text-inputs},
 select[multiple=multiple] {
-  @include box-sizing(border-box);
-  @include transition(border-color);
+  box-sizing: border-box;
+  transition: border-color;
   background-color: white;
   border-radius: $form-border-radius;
   border: 1px solid $form-border-color;
@@ -57,7 +57,7 @@ textarea {
 }
 
 input[type="search"] {
-  @include appearance(none);
+  appearance: none;
 }
 
 input[type="checkbox"], input[type="radio"] {

--- a/source/stylesheets/base/_grid-settings.scss
+++ b/source/stylesheets/base/_grid-settings.scss
@@ -4,11 +4,11 @@
 // $column: 90px;
 // $gutter: 30px;
 // $grid-columns: 12;
-$max-width: em(700);
+$max-width: 700px;
 
 // Neat Breakpoints
-$medium-screen: em(640);
-$large-screen: em(860);
+$medium-screen: 640px;
+$large-screen: 860px;
 
 $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
 $large-screen-up: new-breakpoint(min-width $large-screen 8);

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -43,7 +43,7 @@ p {
 }
 
 a {
-  @include transition(color 0.1s linear);
+  transition: color 0.1s linear;
   color: $base-link-color;
   text-decoration: none;
 

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -9,7 +9,7 @@ $base-font-size: 1em;
 $base-line-height: $base-font-size * 1.5;
 $unitless-line-height: $base-line-height / ($base-line-height * 0 + 1); // Strip units from line-height: https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Prefer_unitless_numbers_for_line-height_values
 $header-line-height: $base-font-size * 1.25;
-$base-border-radius: em(3);
+$base-border-radius: 3em;
 
 // Colors
 $blue: #477DCA;

--- a/source/stylesheets/partials/_nav.css.scss
+++ b/source/stylesheets/partials/_nav.css.scss
@@ -1,6 +1,6 @@
 nav {
   border-bottom: 1px solid $base-border-color;
-  margin: em(30) 0;
+  margin: 30px 0;
 
   .fa-rss {
     margin-top: 12px;
@@ -10,7 +10,7 @@ nav {
 
   ul {
     display: inline-block;
-    margin-bottom: em(10);
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
`em()` was a bit weird because it wasn't actually producing, say
`700em`, but `~47em`, which causes the calculated value to be `700px`. I
changed all of those to the static calculated pixel values.

Other changes were items that were vendor prefixed by Bourbon. I'm not
super worried about browser support for these, so not going to worry
about finding another prefixing solution.
