### PR TITLE
Upgrades: upgrade Bourbon gem to 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,7 @@ GEM
       bourbon (>= 3.2)
       sass (>= 3.2)
       thor
-    bourbon (4.3.4)
-      sass (~> 3.4)
+    bourbon (6.0.0)
       thor (~> 0.19)
     builder (3.2.4)
     capybara (2.4.4)

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -1,6 +1,6 @@
 // Typography
-$sans-serif: 'Oxygen', $helvetica;
-$serif: $georgia;
+$sans-serif: 'Oxygen', $font-stack-helvetica;
+$serif: $font-stack-georgia;
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;
 


### PR DESCRIPTION
Still needs to go up to 7.0, but blocked, probably by Neat.
