### PR TITLE
Upgrades: remove `neat` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,5 @@ gem 'builder' # For feed.xml.builder
 
 gem 'bitters'
 gem 'bourbon'
-gem 'neat'
 
 gem 'middleman-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,6 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     multi_json (1.15.0)
-    neat (1.9.1)
-      sass (>= 3.3)
-      thor (~> 0.19)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -170,7 +167,6 @@ DEPENDENCIES
   middleman-disqus
   middleman-livereload
   middleman-syntax
-  neat
   nokogiri
   puma
   rack-contrib

--- a/source/stylesheets/all.css.scss
+++ b/source/stylesheets/all.css.scss
@@ -2,7 +2,6 @@
 
 @import 'bourbon';
 @import 'base/base';   /* Bitters needs to be imported before Neat */
-@import 'neat';
 @import 'font-awesome';
 
 @import 'partials/layout';

--- a/source/stylesheets/base/_grid-settings.scss
+++ b/source/stylesheets/base/_grid-settings.scss
@@ -1,5 +1,3 @@
-@import 'neat-helpers'; // or '../neat/neat-helpers' when not in Rails
-
 // Neat Overrides
 // $column: 90px;
 // $gutter: 30px;

--- a/source/stylesheets/partials/_layout.css.scss
+++ b/source/stylesheets/partials/_layout.css.scss
@@ -1,5 +1,7 @@
 #main {
-  @include outer-container;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 ol {
@@ -21,9 +23,11 @@ ol {
 }
 
 .large-column {
-  @include span-columns(8 of 12);
+  float: left;
+  width: 66%;
 }
 
 .small-column {
-  @include span-columns(4 of 12);
+  float: left;
+  width: 34%;
 }


### PR DESCRIPTION
The gem [has been deprecated][depr] in favor of native CSS solutions
like Grid and Flexbox. For now I hacked together "good enough" CSS to
emulate what was there.

[depr]: https://github.com/thoughtbot/neat
