### PR TITLE
Deps: lock down haml version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'http://rubygems.org'
 
 ruby '3.0.4'
 
+gem 'haml', '~> 5.2'
 gem 'middleman'
 gem 'middleman-blog'
 gem 'middleman-syntax'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ PLATFORMS
 
 DEPENDENCIES
   builder
+  haml (~> 5.2)
   middleman
   middleman-blog
   middleman-livereload
@@ -149,4 +150,4 @@ RUBY VERSION
    ruby 3.0.4
 
 BUNDLED WITH
-   2.1.4
+   2.2.26


### PR DESCRIPTION
The latest haml version breaks with middleman.
